### PR TITLE
Cache e-mail regex

### DIFF
--- a/verify_email/verify_email.py
+++ b/verify_email/verify_email.py
@@ -7,7 +7,7 @@ import socket
 import threading
 import collections.abc as abc
 
-
+EMAIL_REGEX = r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)'
 MX_DNS_CACHE = {}
 MX_CHECK_CACHE = {}
 
@@ -58,7 +58,7 @@ async def handler_verify(mx_hosts, email, debug, timeout=None):
 
 
 async def syntax_check(email):
-    if re.match(r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)', email):
+    if re.match(EMAIL_REGEX, email):
         return True
     return False
 


### PR DESCRIPTION
This PR caches the e-mail regex so that:
1) it is compiled right away when the module is imported for the first time
2) it is always cached

Please note that this optimization can't be seen right away as Python regexes are cached internally (see also https://stackoverflow.com/questions/452104/is-it-worth-using-pythons-re-compile) BUT the internal cache has a maximum size and if an application uses more regexes (without caching them explicitly) the internal cache may clobber and regexes might get re-compiled many times.

This being said, it is always better to cache regexes if they are going to be reused.