### PR TITLE
Fix name 'sys' is not defined issue

### DIFF
--- a/build/lib/verify_email/verify_email.py
+++ b/build/lib/verify_email/verify_email.py
@@ -6,6 +6,7 @@ import smtplib
 import socket
 import threading
 import collections.abc as abc
+import sys
 
 EMAIL_REGEX = r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)'
 MX_DNS_CACHE = {}


### PR DESCRIPTION
English is not my native language; please excuse typing errors.

`from verify_email import verify_email`
`verify_email('r1235613@gmail.com')`
`Traceback (most recent call last):`
`  File "<input>", line 1, in <module>`
`  File "C:\Users\r1235\PycharmProjects\game_ecpay\venv\lib\site-packages\verify_email\verify_email.py", line 100, in verify_email`
`    if sys.platform == "win32":`
`NameError: name 'sys' is not defined`

I added `import sys` at [verify_email.py#9](https://github.com/r1235613/verify_email/blob/master/build/lib/verify_email/verify_email.py#L9) to fix this issue.
This may be the cause of the problem.
![螢幕擷取畫面 2021-02-07 213254](https://user-images.githubusercontent.com/14368787/107148051-109d1500-698c-11eb-9aaa-ba172bdb70da.png)
 This problem is happing on Windows 10 with python 3.8.7